### PR TITLE
Change to use executorType of SqlSessionFactory instead of SIMPLE by default

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
 import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
@@ -129,10 +130,13 @@ public class MybatisAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
-		return new SqlSessionTemplate(sqlSessionFactory,
-				this.properties.getExecutorType() != null ?
-						this.properties.getExecutorType() :
-						sqlSessionFactory.getConfiguration().getDefaultExecutorType());
+		ExecutorType executorType = this.properties.getExecutorType();
+		if (executorType != null) {
+			return new SqlSessionTemplate(sqlSessionFactory, executorType);
+		}
+		else {
+			return new SqlSessionTemplate(sqlSessionFactory);
+		}
 	}
 
 	/**

--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -67,6 +67,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Eddú Meléndez
  * @author Josh Long
+ * @author Kazuki Shimizu
  */
 @Configuration
 @ConditionalOnClass({ SqlSessionFactory.class, SqlSessionFactoryBean.class })
@@ -129,7 +130,9 @@ public class MybatisAutoConfiguration {
 	@ConditionalOnMissingBean
 	public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
 		return new SqlSessionTemplate(sqlSessionFactory,
-				this.properties.getExecutorType());
+				this.properties.getExecutorType() != null ?
+						this.properties.getExecutorType() :
+						sqlSessionFactory.getConfiguration().getDefaultExecutorType());
 	}
 
 	/**

--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
@@ -31,6 +31,7 @@ import java.util.List;
  * Configuration properties for Mybatis.
  *
  * @author Eddú Meléndez
+ * @author Kazuki Shimizu
  */
 @ConfigurationProperties(prefix = MybatisProperties.MYBATIS_PREFIX)
 public class MybatisProperties {
@@ -63,9 +64,9 @@ public class MybatisProperties {
 	private boolean checkConfigLocation = false;
 
 	/**
-	 * Execution mode.
+	 * Execution mode for {@link org.mybatis.spring.SqlSessionTemplate}.
 	 */
-	private ExecutorType executorType = ExecutorType.SIMPLE;
+	private ExecutorType executorType;
 
 	public String getConfig() {
 		return this.config;

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -90,7 +90,7 @@ public class MybatisAutoConfigurationTest {
 		assertEquals(1,
 				this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
-		assertEquals(ExecutorType.SIMPLE, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
+		assertEquals(ExecutorType.SIMPLE, this.context.getBean(SqlSessionTemplate.class).getExecutorType()); // use a default executor type(SIMPLE)
 	}
 
 	@Test
@@ -103,6 +103,7 @@ public class MybatisAutoConfigurationTest {
 		this.context.refresh();
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapperImpl.class).length);
+		assertEquals(ExecutorType.BATCH, this.context.getBean(SqlSessionTemplate.class).getExecutorType()); // use a executor type that specify on config file
 	}
 
 	@Test
@@ -133,7 +134,9 @@ public class MybatisAutoConfigurationTest {
 	@Test
 	public void testWithExecutorType() {
 		EnvironmentTestUtils.addEnvironment(this.context,
-				"mybatis.executorType:REUSE");
+				"mybatis.config:mybatis-config.xml");
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.executorType:REUSE"); // use a executor type that specify on spring's properties(or yaml)
 		this.context.register(EmbeddedDataSourceConfiguration.class,
 				MybatisAutoConfiguration.class, MybatisMapperConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class);

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -90,7 +90,7 @@ public class MybatisAutoConfigurationTest {
 		assertEquals(1,
 				this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
-		assertEquals(ExecutorType.SIMPLE, this.context.getBean(SqlSessionTemplate.class).getExecutorType()); // use a default executor type(SIMPLE)
+		assertEquals(ExecutorType.SIMPLE, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
 	}
 
 	@Test
@@ -103,7 +103,7 @@ public class MybatisAutoConfigurationTest {
 		this.context.refresh();
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapperImpl.class).length);
-		assertEquals(ExecutorType.BATCH, this.context.getBean(SqlSessionTemplate.class).getExecutorType()); // use a executor type that specify on config file
+		assertEquals(ExecutorType.BATCH, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
 	}
 
 	@Test
@@ -134,14 +134,13 @@ public class MybatisAutoConfigurationTest {
 	@Test
 	public void testWithExecutorType() {
 		EnvironmentTestUtils.addEnvironment(this.context,
-				"mybatis.config:mybatis-config.xml");
-		EnvironmentTestUtils.addEnvironment(this.context,
-				"mybatis.executorType:REUSE"); // use a executor type that specify on spring's properties(or yaml)
+				"mybatis.config:mybatis-config.xml", "mybatis.executor-type:REUSE");
 		this.context.register(EmbeddedDataSourceConfiguration.class,
 				MybatisAutoConfiguration.class, MybatisMapperConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class);
 		this.context.refresh();
-		assertEquals(ExecutorType.REUSE, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
+		assertEquals(ExecutorType.REUSE, this.context.getBean(SqlSessionTemplate.class)
+				.getExecutorType());
 	}
 
 	@Test

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -29,6 +29,7 @@ import org.apache.ibatis.plugin.Intercepts;
 import org.apache.ibatis.plugin.Invocation;
 import org.apache.ibatis.plugin.Plugin;
 import org.apache.ibatis.plugin.Signature;
+import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.type.TypeHandlerRegistry;
 import org.junit.After;
@@ -53,6 +54,7 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Eddú Meléndez
  * @author Josh Long
+ * @author Kazuki Shimizu
  */
 public class MybatisAutoConfigurationTest {
 
@@ -88,6 +90,7 @@ public class MybatisAutoConfigurationTest {
 		assertEquals(1,
 				this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
+		assertEquals(ExecutorType.SIMPLE, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
 	}
 
 	@Test
@@ -125,6 +128,17 @@ public class MybatisAutoConfigurationTest {
 				PropertyPlaceholderAutoConfiguration.class);
 		this.context.refresh();
 		assertEquals(2, this.context.getBean(SqlSessionFactory.class).getConfiguration().getMappedStatementNames().size());
+	}
+
+	@Test
+	public void testWithExecutorType() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.executorType:REUSE");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisAutoConfiguration.class, MybatisMapperConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+		assertEquals(ExecutorType.REUSE, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
 	}
 
 	@Test

--- a/mybatis-spring-boot-autoconfigure/src/test/resources/mybatis-config.xml
+++ b/mybatis-spring-boot-autoconfigure/src/test/resources/mybatis-config.xml
@@ -3,6 +3,9 @@
         PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-config.dtd">
 <configuration>
+    <settings>
+        <setting name="defaultExecutorType" value="BATCH"/>
+    </settings>
     <typeAliases>
         <package name="org.mybatis.spring.boot.autoconfigure.domain"/>
     </typeAliases>


### PR DESCRIPTION
In currently implementation, executor type of `SqlSessionTemplate` is fixed to `SIMPLE` by default.
However, i think that it should be change to use `Configuration#getDefaultExecutorType()` of injected `SqlSessionFactory` .

What do you think ?
