### PR TITLE
Allow mixed configurations using mybatis config file and type-safe configuration properties

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -67,6 +67,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Eddú Meléndez
  * @author Josh Long
+ * @author Kazuki Shimizu
  */
 @Configuration
 @ConditionalOnClass({ SqlSessionFactory.class, SqlSessionFactoryBean.class })
@@ -110,17 +111,15 @@ public class MybatisAutoConfiguration {
 			factory.setConfigLocation(this.resourceLoader.getResource(this.properties
 					.getConfig()));
 		}
-		else {
-			if (this.interceptors != null && this.interceptors.length > 0) {
-				factory.setPlugins(this.interceptors);
-			}
-			if (this.databaseIdProvider != null) {
-				factory.setDatabaseIdProvider(this.databaseIdProvider);
-			}
-			factory.setTypeAliasesPackage(this.properties.getTypeAliasesPackage());
-			factory.setTypeHandlersPackage(this.properties.getTypeHandlersPackage());
-			factory.setMapperLocations(this.properties.resolveMapperLocations());
+		if (this.interceptors != null && this.interceptors.length > 0) {
+			factory.setPlugins(this.interceptors);
 		}
+		if (this.databaseIdProvider != null) {
+			factory.setDatabaseIdProvider(this.databaseIdProvider);
+		}
+		factory.setTypeAliasesPackage(this.properties.getTypeAliasesPackage());
+		factory.setTypeHandlersPackage(this.properties.getTypeHandlersPackage());
+		factory.setMapperLocations(this.properties.resolveMapperLocations());
 
 		return factory.getObject();
 	}

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -169,65 +169,36 @@ public class MybatisAutoConfigurationTest {
 
 	@Test
 	public void testMixedConfigurations() {
-		// set up
-		{
-			EnvironmentTestUtils.addEnvironment(this.context
-					, "mybatis.config:mybatis-config-settings-only.xml"
-					, "mybatis.typeHandlersPackage:org.mybatis.spring.boot.autoconfigure.handler"
-					, "mybatis.typeAliasesPackage:org.mybatis.spring.boot.autoconfigure.domain"
-					, "mybatis.mapperLocations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
-					, "mybatis.executorType=REUSE"
-			);
-			this.context.register(
-					EmbeddedDataSourceConfiguration.class
-					, MybatisBootMapperScanAutoConfiguration.class
-					, MybatisInterceptorConfiguration.class
-					, DatabaseProvidersConfiguration.class
-			);
-		}
-		// run test
-		{
-			this.context.refresh();
-		}
+		EnvironmentTestUtils.addEnvironment(this.context
+				, "mybatis.config:mybatis-config-settings-only.xml"
+				, "mybatis.typeHandlersPackage:org.mybatis.spring.boot.autoconfigure.handler"
+				, "mybatis.typeAliasesPackage:org.mybatis.spring.boot.autoconfigure.domain"
+				, "mybatis.mapperLocations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
+				, "mybatis.executorType=REUSE"
+		);
+		this.context.register(
+				EmbeddedDataSourceConfiguration.class
+				, MybatisBootMapperScanAutoConfiguration.class
+				, MybatisInterceptorConfiguration.class
+				, DatabaseProvidersConfiguration.class
+		);
+		this.context.refresh();
 
-		// assert test
 		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
-		{
-			// assert for components created by auto configuration
-			assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
-			assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
-			assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
-		}
-		{
-			// assert for 'mybatis.config'
-			assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
-		}
-		{
-			// assert for 'mybatis.typeHandlersPackage'
-			assertEquals(DummyTypeHandler.class, configuration.getTypeHandlerRegistry().getTypeHandler(BigInteger.class).getClass());
-		}
-		{
-			// assert for 'mybatis.typeAliasesPackage' and 'mybatis.mapperLocations', auto mapper scan
-			assertEquals(4, configuration.getMappedStatementNames().size());
-			assertTrue(configuration.getMappedStatementNames().contains("selectCityById"));
-			assertTrue(configuration.getMappedStatementNames().contains("org.mybatis.spring.boot.autoconfigure.repository.CityMapperImpl.selectCityById"));
-			// assert auto mapper scan
-			assertTrue(configuration.getMappedStatementNames().contains("findById"));
-			assertTrue(configuration.getMappedStatementNames().contains("org.mybatis.spring.boot.autoconfigure.mapper.CityMapper.findById"));
-		}
-		{
-			// assert for 'mybatis.executorType'
-			assertEquals(ExecutorType.REUSE, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
-		}
-		{
-			// assert for injecting a Interceptor
-			assertEquals(1, configuration.getInterceptors().size());
-			assertEquals(MyInterceptor.class, configuration.getInterceptors().get(0).getClass());
-		}
-		{
-			// assert for injecting a DatabaseIdProvider
-			assertEquals("h2", configuration.getDatabaseId());
-		}
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
+		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
+		assertEquals(DummyTypeHandler.class, configuration.getTypeHandlerRegistry().getTypeHandler(BigInteger.class).getClass());
+		assertEquals(4, configuration.getMappedStatementNames().size());
+		assertTrue(configuration.getMappedStatementNames().contains("selectCityById"));
+		assertTrue(configuration.getMappedStatementNames().contains("org.mybatis.spring.boot.autoconfigure.repository.CityMapperImpl.selectCityById"));
+		assertTrue(configuration.getMappedStatementNames().contains("findById"));
+		assertTrue(configuration.getMappedStatementNames().contains("org.mybatis.spring.boot.autoconfigure.mapper.CityMapper.findById"));
+		assertEquals(ExecutorType.REUSE, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
+		assertEquals(1, configuration.getInterceptors().size());
+		assertEquals(MyInterceptor.class, configuration.getInterceptors().get(0).getClass());
+		assertEquals("h2", configuration.getDatabaseId());
 	}
 
 	@Configuration

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -168,7 +168,89 @@ public class MybatisAutoConfigurationTest {
 	}
 
 	@Test
-	public void testMixedConfigurations() {
+	public void testMixedWithConfigurationFileAndInterceptor() {
+		EnvironmentTestUtils.addEnvironment(this.context
+				, "mybatis.config:mybatis-config-settings-only.xml"
+		);
+		this.context.register(
+				EmbeddedDataSourceConfiguration.class
+				, MybatisInterceptorConfiguration.class
+		);
+		this.context.refresh();
+
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
+		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
+		assertEquals(1, configuration.getInterceptors().size());
+		assertEquals(MyInterceptor.class, configuration.getInterceptors().get(0).getClass());
+	}
+
+	@Test
+	public void testMixedWithConfigurationFileAndDatabaseIdProvider() {
+		EnvironmentTestUtils.addEnvironment(this.context
+				, "mybatis.config:mybatis-config-settings-only.xml"
+		);
+		this.context.register(
+				EmbeddedDataSourceConfiguration.class
+				, MybatisBootMapperScanAutoConfiguration.class
+				, DatabaseProvidersConfiguration.class
+		);
+		this.context.refresh();
+
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
+		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
+		assertEquals("h2", configuration.getDatabaseId());
+	}
+
+	@Test
+	public void testMixedWithConfigurationFileAndTypeHandlersPackage() {
+		EnvironmentTestUtils.addEnvironment(this.context
+				, "mybatis.config:mybatis-config-settings-only.xml"
+				, "mybatis.typeHandlersPackage:org.mybatis.spring.boot.autoconfigure.handler"
+		);
+		this.context.register(
+				EmbeddedDataSourceConfiguration.class
+				, MybatisBootMapperScanAutoConfiguration.class
+		);
+		this.context.refresh();
+
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
+		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
+		assertEquals(DummyTypeHandler.class, configuration.getTypeHandlerRegistry().getTypeHandler(BigInteger.class).getClass());
+	}
+
+	@Test
+	public void testMixedWithConfigurationFileAndTypeAliasesPackageAndMapperLocations() {
+		EnvironmentTestUtils.addEnvironment(this.context
+				, "mybatis.config:mybatis-config-settings-only.xml"
+				, "mybatis.typeAliasesPackage:org.mybatis.spring.boot.autoconfigure.domain"
+				, "mybatis.mapperLocations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
+		);
+		this.context.register(
+				EmbeddedDataSourceConfiguration.class
+				, MybatisBootMapperScanAutoConfiguration.class
+		);
+		this.context.refresh();
+
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
+		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
+		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
+		assertTrue(configuration.getMappedStatementNames().contains("selectCityById"));
+		assertTrue(configuration.getMappedStatementNames().contains("org.mybatis.spring.boot.autoconfigure.repository.CityMapperImpl.selectCityById"));
+	}
+
+	@Test
+	public void testMixedWithFullConfigurations() {
 		EnvironmentTestUtils.addEnvironment(this.context
 				, "mybatis.config:mybatis-config-settings-only.xml"
 				, "mybatis.typeHandlersPackage:org.mybatis.spring.boot.autoconfigure.handler"

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -211,7 +211,7 @@ public class MybatisAutoConfigurationTest {
 	public void testMixedWithConfigurationFileAndTypeHandlersPackage() {
 		EnvironmentTestUtils.addEnvironment(this.context
 				, "mybatis.config:mybatis-config-settings-only.xml"
-				, "mybatis.typeHandlersPackage:org.mybatis.spring.boot.autoconfigure.handler"
+				, "mybatis.type-handlers-package:org.mybatis.spring.boot.autoconfigure.handler"
 		);
 		this.context.register(
 				EmbeddedDataSourceConfiguration.class
@@ -231,8 +231,8 @@ public class MybatisAutoConfigurationTest {
 	public void testMixedWithConfigurationFileAndTypeAliasesPackageAndMapperLocations() {
 		EnvironmentTestUtils.addEnvironment(this.context
 				, "mybatis.config:mybatis-config-settings-only.xml"
-				, "mybatis.typeAliasesPackage:org.mybatis.spring.boot.autoconfigure.domain"
-				, "mybatis.mapperLocations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
+				, "mybatis.type-aliases-package:org.mybatis.spring.boot.autoconfigure.domain"
+				, "mybatis.mapper-locations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
 		);
 		this.context.register(
 				EmbeddedDataSourceConfiguration.class
@@ -253,10 +253,10 @@ public class MybatisAutoConfigurationTest {
 	public void testMixedWithFullConfigurations() {
 		EnvironmentTestUtils.addEnvironment(this.context
 				, "mybatis.config:mybatis-config-settings-only.xml"
-				, "mybatis.typeHandlersPackage:org.mybatis.spring.boot.autoconfigure.handler"
-				, "mybatis.typeAliasesPackage:org.mybatis.spring.boot.autoconfigure.domain"
-				, "mybatis.mapperLocations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
-				, "mybatis.executorType=REUSE"
+				, "mybatis.type-handlers-package:org.mybatis.spring.boot.autoconfigure.handler"
+				, "mybatis.type-aliases-package:org.mybatis.spring.boot.autoconfigure.domain"
+				, "mybatis.mapper-locations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
+				, "mybatis.executor-type=REUSE"
 		);
 		this.context.register(
 				EmbeddedDataSourceConfiguration.class

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -169,37 +169,34 @@ public class MybatisAutoConfigurationTest {
 
 	@Test
 	public void testMixedWithConfigurationFileAndInterceptor() {
-		EnvironmentTestUtils.addEnvironment(this.context
-				, "mybatis.config:mybatis-config-settings-only.xml"
-		);
-		this.context.register(
-				EmbeddedDataSourceConfiguration.class
-				, MybatisInterceptorConfiguration.class
-		);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.config:mybatis-config-settings-only.xml");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisInterceptorConfiguration.class);
 		this.context.refresh();
 
-		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(
+				SqlSessionFactory.class).getConfiguration();
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
 		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
 		assertEquals(1, configuration.getInterceptors().size());
-		assertEquals(MyInterceptor.class, configuration.getInterceptors().get(0).getClass());
+		assertEquals(MyInterceptor.class, configuration.getInterceptors().get(0)
+				.getClass());
 	}
 
 	@Test
 	public void testMixedWithConfigurationFileAndDatabaseIdProvider() {
-		EnvironmentTestUtils.addEnvironment(this.context
-				, "mybatis.config:mybatis-config-settings-only.xml"
-		);
-		this.context.register(
-				EmbeddedDataSourceConfiguration.class
-				, MybatisBootMapperScanAutoConfiguration.class
-				, DatabaseProvidersConfiguration.class
-		);
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.config:mybatis-config-settings-only.xml");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisBootMapperScanAutoConfiguration.class,
+				DatabaseProvidersConfiguration.class);
 		this.context.refresh();
 
-		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(
+				SqlSessionFactory.class).getConfiguration();
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
@@ -209,77 +206,87 @@ public class MybatisAutoConfigurationTest {
 
 	@Test
 	public void testMixedWithConfigurationFileAndTypeHandlersPackage() {
-		EnvironmentTestUtils.addEnvironment(this.context
-				, "mybatis.config:mybatis-config-settings-only.xml"
-				, "mybatis.type-handlers-package:org.mybatis.spring.boot.autoconfigure.handler"
-		);
-		this.context.register(
-				EmbeddedDataSourceConfiguration.class
-				, MybatisBootMapperScanAutoConfiguration.class
-		);
+		EnvironmentTestUtils
+				.addEnvironment(this.context,
+						"mybatis.config:mybatis-config-settings-only.xml",
+						"mybatis.type-handlers-package:org.mybatis.spring.boot.autoconfigure.handler");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisBootMapperScanAutoConfiguration.class);
 		this.context.refresh();
 
-		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(
+				SqlSessionFactory.class).getConfiguration();
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
 		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
-		assertEquals(DummyTypeHandler.class, configuration.getTypeHandlerRegistry().getTypeHandler(BigInteger.class).getClass());
+		assertEquals(DummyTypeHandler.class, configuration.getTypeHandlerRegistry()
+				.getTypeHandler(BigInteger.class).getClass());
 	}
 
 	@Test
 	public void testMixedWithConfigurationFileAndTypeAliasesPackageAndMapperLocations() {
-		EnvironmentTestUtils.addEnvironment(this.context
-				, "mybatis.config:mybatis-config-settings-only.xml"
-				, "mybatis.type-aliases-package:org.mybatis.spring.boot.autoconfigure.domain"
-				, "mybatis.mapper-locations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
-		);
-		this.context.register(
-				EmbeddedDataSourceConfiguration.class
-				, MybatisBootMapperScanAutoConfiguration.class
-		);
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"mybatis.config:mybatis-config-settings-only.xml",
+						"mybatis.type-aliases-package:org.mybatis.spring.boot.autoconfigure.domain",
+						"mybatis.mapper-locations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisBootMapperScanAutoConfiguration.class);
 		this.context.refresh();
 
-		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(
+				SqlSessionFactory.class).getConfiguration();
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
 		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
 		assertTrue(configuration.getMappedStatementNames().contains("selectCityById"));
-		assertTrue(configuration.getMappedStatementNames().contains("org.mybatis.spring.boot.autoconfigure.repository.CityMapperImpl.selectCityById"));
+		assertTrue(configuration
+				.getMappedStatementNames()
+				.contains(
+						"org.mybatis.spring.boot.autoconfigure.repository.CityMapperImpl.selectCityById"));
 	}
 
 	@Test
 	public void testMixedWithFullConfigurations() {
-		EnvironmentTestUtils.addEnvironment(this.context
-				, "mybatis.config:mybatis-config-settings-only.xml"
-				, "mybatis.type-handlers-package:org.mybatis.spring.boot.autoconfigure.handler"
-				, "mybatis.type-aliases-package:org.mybatis.spring.boot.autoconfigure.domain"
-				, "mybatis.mapper-locations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml"
-				, "mybatis.executor-type=REUSE"
-		);
-		this.context.register(
-				EmbeddedDataSourceConfiguration.class
-				, MybatisBootMapperScanAutoConfiguration.class
-				, MybatisInterceptorConfiguration.class
-				, DatabaseProvidersConfiguration.class
-		);
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"mybatis.config:mybatis-config-settings-only.xml",
+						"mybatis.type-handlers-package:org.mybatis.spring.boot.autoconfigure.handler",
+						"mybatis.type-aliases-package:org.mybatis.spring.boot.autoconfigure.domain",
+						"mybatis.mapper-locations:classpath:org/mybatis/spring/boot/autoconfigure/repository/CityMapper.xml",
+						"mybatis.executor-type=REUSE");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisBootMapperScanAutoConfiguration.class,
+				MybatisInterceptorConfiguration.class,
+				DatabaseProvidersConfiguration.class);
 		this.context.refresh();
 
-		org.apache.ibatis.session.Configuration configuration = this.context.getBean(SqlSessionFactory.class).getConfiguration();
+		org.apache.ibatis.session.Configuration configuration = this.context.getBean(
+				SqlSessionFactory.class).getConfiguration();
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(SqlSessionTemplate.class).length);
 		assertEquals(1, this.context.getBeanNamesForType(CityMapper.class).length);
 		assertEquals(Integer.valueOf(1000), configuration.getDefaultFetchSize());
-		assertEquals(DummyTypeHandler.class, configuration.getTypeHandlerRegistry().getTypeHandler(BigInteger.class).getClass());
+		assertEquals(DummyTypeHandler.class, configuration.getTypeHandlerRegistry()
+				.getTypeHandler(BigInteger.class).getClass());
 		assertEquals(4, configuration.getMappedStatementNames().size());
 		assertTrue(configuration.getMappedStatementNames().contains("selectCityById"));
-		assertTrue(configuration.getMappedStatementNames().contains("org.mybatis.spring.boot.autoconfigure.repository.CityMapperImpl.selectCityById"));
+		assertTrue(configuration
+				.getMappedStatementNames()
+				.contains(
+						"org.mybatis.spring.boot.autoconfigure.repository.CityMapperImpl.selectCityById"));
 		assertTrue(configuration.getMappedStatementNames().contains("findById"));
-		assertTrue(configuration.getMappedStatementNames().contains("org.mybatis.spring.boot.autoconfigure.mapper.CityMapper.findById"));
-		assertEquals(ExecutorType.REUSE, this.context.getBean(SqlSessionTemplate.class).getExecutorType());
+		assertTrue(configuration.getMappedStatementNames().contains(
+				"org.mybatis.spring.boot.autoconfigure.mapper.CityMapper.findById"));
+		assertEquals(ExecutorType.REUSE, this.context.getBean(SqlSessionTemplate.class)
+				.getExecutorType());
 		assertEquals(1, configuration.getInterceptors().size());
-		assertEquals(MyInterceptor.class, configuration.getInterceptors().get(0).getClass());
+		assertEquals(MyInterceptor.class, configuration.getInterceptors().get(0)
+				.getClass());
 		assertEquals("h2", configuration.getDatabaseId());
 	}
 

--- a/mybatis-spring-boot-autoconfigure/src/test/resources/mybatis-config-settings-only.xml
+++ b/mybatis-spring-boot-autoconfigure/src/test/resources/mybatis-config-settings-only.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <settings>
+        <setting name="defaultFetchSize" value="1000"/>
+    </settings>
+</configuration>


### PR DESCRIPTION
I've tried that allow mixed configurations using mybatis config(`mybatis-config.xml`) file and type-safe configuration properties(`application.properties`).
A build is successful in my local machine (JDK 1.8 + maven wrapper).
Please review this.
