### PR TITLE
Modify a assertion method for specifying with 'configuration' and 'configLocation'

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -377,7 +377,7 @@ public class MybatisAutoConfigurationTest {
 
 		expectedException.expect(isA(BeanCreationException.class));
 		expectedException
-				.expectMessage(is("Error creating bean with name 'sqlSessionFactory' defined in org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.apache.ibatis.session.SqlSessionFactory]: Factory method 'sqlSessionFactory' threw exception; nested exception is java.lang.IllegalStateException: Property 'configuration' and 'configLocation' can not specified with together"));
+				.expectMessage("Property 'configuration' and 'configLocation' can not specified with together");
 
 		this.context.refresh();
 	}


### PR DESCRIPTION
I've modified assertion for specifying at the same time with 'configuration' and 'configLocation' because an error message is not fixed.