### PR TITLE
Add condition for checking presence of a config file

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -94,7 +94,7 @@ public class MybatisAutoConfiguration {
 
   @PostConstruct
   public void checkConfigFileExists() {
-    if (this.properties.isCheckConfigLocation()) {
+    if (this.properties.isCheckConfigLocation() && StringUtils.hasText(this.properties.getConfigLocation())) {
       Resource resource = this.resourceLoader.getResource(this.properties.getConfigLocation());
       Assert.state(resource.exists(), "Cannot find config location: " + resource
           + " (please add config file or check your Mybatis " + "configuration)");

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -129,6 +129,16 @@ public class MybatisAutoConfigurationTest {
 	}
 
 	@Test
+	public void testWithCheckConfigLocationFileNotSpecify() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.check-config-location=true");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisAutoConfiguration.class);
+		this.context.refresh();
+		assertEquals(1, this.context.getBeanNamesForType(SqlSessionFactory.class).length);
+	}
+
+	@Test
 	public void testWithCheckConfigLocationFileDoesNotExists() {
 
 		EnvironmentTestUtils.addEnvironment(this.context, "mybatis.config:foo.xml",


### PR DESCRIPTION
When `check-config-location` is `true` and `config-location` not present, following error occurred.

```
...
Caused by: java.lang.IllegalArgumentException: Location must not be null
	at org.springframework.util.Assert.notNull(Assert.java:115)
	at org.springframework.core.io.DefaultResourceLoader.getResource(DefaultResourceLoader.java:90)
	at org.springframework.context.support.GenericApplicationContext.getResource(GenericApplicationContext.java:211)
	at org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration.checkConfigFileExists(MybatisAutoConfiguration.java:98)
...
```

I think this case should skip a check.