### PR TITLE
Configuration properties export to spring-configuration-metadata.json

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ExecutorType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
@@ -71,6 +72,7 @@ public class MybatisProperties {
    * A Configuration object for customize default settings. If {@link #configLocation}
    * is specified, this property is not used.
    */
+  @NestedConfigurationProperty
   private Configuration configuration;
 
   /**


### PR DESCRIPTION
I've modified to export metadata of the `Configuration`.
Please review.

See http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#configuration-metadata-nested-properties.