### PR TITLE
Ignore auto configuration when detect multiple datasource

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -15,44 +15,27 @@
  */
 package org.mybatis.spring.boot.autoconfigure;
 
-import java.util.List;
-
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
 import org.apache.ibatis.plugin.Interceptor;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
-import org.mybatis.spring.mapper.ClassPathMapperScanner;
-import org.mybatis.spring.mapper.MapperFactoryBean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -72,25 +55,16 @@ import org.springframework.util.StringUtils;
  * @author Eduardo Macarrón
  */
 @Configuration
-@ConditionalOnClass({ SqlSessionFactory.class, SqlSessionFactoryBean.class })
-@ConditionalOnBean(DataSource.class)
+@ConditionalOnClass(org.apache.ibatis.session.Configuration.class)
 @EnableConfigurationProperties(MybatisProperties.class)
 @AutoConfigureAfter(DataSourceAutoConfiguration.class)
 public class MybatisAutoConfiguration {
 
-  private static Logger logger = LoggerFactory.getLogger(MybatisAutoConfiguration.class);
-
   @Autowired
   private MybatisProperties properties;
 
-  @Autowired(required = false)
-  private Interceptor[] interceptors;
-
   @Autowired
-  private ResourceLoader resourceLoader = new DefaultResourceLoader();
-
-  @Autowired(required = false)
-  private DatabaseIdProvider databaseIdProvider;
+  private ResourceLoader resourceLoader;
 
   @PostConstruct
   public void checkConfigFileExists() {
@@ -101,115 +75,63 @@ public class MybatisAutoConfiguration {
     }
   }
 
-  @Bean
-  @ConditionalOnMissingBean
-  public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
-    SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
-    factory.setDataSource(dataSource);
-    factory.setVfs(SpringBootVFS.class);
-    if (StringUtils.hasText(this.properties.getConfigLocation())) {
-      factory.setConfigLocation(this.resourceLoader.getResource(this.properties.getConfigLocation()));
-    }
-    factory.setConfiguration(properties.getConfiguration());
-    if (!ObjectUtils.isEmpty(this.interceptors)) {
-      factory.setPlugins(this.interceptors);
-    }
-    if (this.databaseIdProvider != null) {
-      factory.setDatabaseIdProvider(this.databaseIdProvider);
-    }
-    if (StringUtils.hasLength(this.properties.getTypeAliasesPackage())) {
-      factory.setTypeAliasesPackage(this.properties.getTypeAliasesPackage());
-    }
-    if (StringUtils.hasLength(this.properties.getTypeHandlersPackage())) {
-      factory.setTypeHandlersPackage(this.properties.getTypeHandlersPackage());
-    }
-    if (!ObjectUtils.isEmpty(this.properties.resolveMapperLocations())) {
-      factory.setMapperLocations(this.properties.resolveMapperLocations());
-    }
+  @Configuration
+  @ConditionalOnClass({ SqlSessionFactory.class, SqlSessionFactoryBean.class })
+  @ConditionalOnSingleCandidate(DataSource.class)
+  static class SqlSessionConfiguration {
 
-    return factory.getObject();
-  }
+    @Autowired
+    private MybatisProperties properties;
 
-  @Bean
-  @ConditionalOnMissingBean
-  public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
-    ExecutorType executorType = this.properties.getExecutorType();
-    if (executorType != null) {
-      return new SqlSessionTemplate(sqlSessionFactory, executorType);
-    } else {
-      return new SqlSessionTemplate(sqlSessionFactory);
-    }
-  }
+    @Autowired(required = false)
+    private Interceptor[] interceptors;
 
-  /**
-   * This will just scan the same base package as Spring Boot does. If you want
-   * more power, you can explicitly use
-   * {@link org.mybatis.spring.annotation.MapperScan} but this will get typed
-   * mappers working correctly, out-of-the-box, similar to using Spring Data JPA
-   * repositories.
-   */
-  public static class AutoConfiguredMapperScannerRegistrar
-      implements BeanFactoryAware, ImportBeanDefinitionRegistrar, ResourceLoaderAware {
+    @Autowired(required = false)
+    private DatabaseIdProvider databaseIdProvider;
 
-    private BeanFactory beanFactory;
-
+    @Autowired
     private ResourceLoader resourceLoader;
 
-    @Override
-    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+    @Bean
+    @ConditionalOnMissingBean
+    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+      SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
+      factory.setDataSource(dataSource);
+      factory.setVfs(SpringBootVFS.class);
+      if (StringUtils.hasText(this.properties.getConfigLocation())) {
+        factory.setConfigLocation(this.resourceLoader.getResource(this.properties.getConfigLocation()));
+      }
+      factory.setConfiguration(properties.getConfiguration());
+      if (!ObjectUtils.isEmpty(this.interceptors)) {
+        factory.setPlugins(this.interceptors);
+      }
+      if (this.databaseIdProvider != null) {
+        factory.setDatabaseIdProvider(this.databaseIdProvider);
+      }
+      if (StringUtils.hasLength(this.properties.getTypeAliasesPackage())) {
+        factory.setTypeAliasesPackage(this.properties.getTypeAliasesPackage());
+      }
+      if (StringUtils.hasLength(this.properties.getTypeHandlersPackage())) {
+        factory.setTypeHandlersPackage(this.properties.getTypeHandlersPackage());
+      }
+      if (!ObjectUtils.isEmpty(this.properties.resolveMapperLocations())) {
+        factory.setMapperLocations(this.properties.resolveMapperLocations());
+      }
 
-      logger.debug("Searching for mappers annotated with @Mapper'");
+      return factory.getObject();
+    }
 
-      ClassPathMapperScanner scanner = new ClassPathMapperScanner(registry);
-
-      try {
-        if (this.resourceLoader != null) {
-          scanner.setResourceLoader(this.resourceLoader);
-        }
-
-        List<String> packages = AutoConfigurationPackages.get(this.beanFactory);
-        if (logger.isDebugEnabled()) {
-          for (String pkg : packages) {
-            logger.debug("Using auto-configuration base package '{}'", pkg);
-          }
-        }
-
-        scanner.setAnnotationClass(Mapper.class);
-        scanner.registerFilters();
-        scanner.doScan(StringUtils.toStringArray(packages));
-      } catch (IllegalStateException ex) {
-        logger.debug("Could not determine auto-configuration package, automatic mapper scanning disabled.");
+    @Bean
+    @ConditionalOnMissingBean
+    public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
+      ExecutorType executorType = this.properties.getExecutorType();
+      if (executorType != null) {
+        return new SqlSessionTemplate(sqlSessionFactory, executorType);
+      } else {
+        return new SqlSessionTemplate(sqlSessionFactory);
       }
     }
 
-    @Override
-    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-      this.beanFactory = beanFactory;
-    }
-
-    @Override
-    public void setResourceLoader(ResourceLoader resourceLoader) {
-      this.resourceLoader = resourceLoader;
-    }
-  }
-
-  /**
-   * {@link org.mybatis.spring.annotation.MapperScan} ultimately ends up
-   * creating instances of {@link MapperFactoryBean}. If
-   * {@link org.mybatis.spring.annotation.MapperScan} is used then this
-   * auto-configuration is not needed. If it is _not_ used, however, then this
-   * will bring in a bean registrar and automatically register components based
-   * on the same component-scanning path as Spring Boot itself.
-   */
-  @Configuration
-  @Import({ AutoConfiguredMapperScannerRegistrar.class })
-  @ConditionalOnMissingBean(MapperFactoryBean.class)
-  public static class MapperScannerRegistrarNotFoundConfiguration {
-
-    @PostConstruct
-    public void afterPropertiesSet() {
-      logger.debug("No {} found.", MapperFactoryBean.class.getName());
-    }
   }
 
 }

--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisMapperAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisMapperAutoConfiguration.java
@@ -1,0 +1,121 @@
+/**
+ *    Copyright 2015-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.boot.autoconfigure;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.session.SqlSession;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.mapper.ClassPathMapperScanner;
+import org.mybatis.spring.mapper.MapperFactoryBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * {@link org.mybatis.spring.annotation.MapperScan} ultimately ends up
+ * creating instances of {@link MapperFactoryBean}. If
+ * {@link org.mybatis.spring.annotation.MapperScan} is used then this
+ * auto-configuration is not needed. If it is _not_ used, however, then this
+ * will bring in a bean registrar and automatically register components based
+ * on the same component-scanning path as Spring Boot itself.
+ *
+ * @since 1.1.2
+ * @author Josh Long
+ * @author Eddú Meléndez
+ * @author Eduardo Macarrón
+ * @author Kazuki Shimizu
+ */
+@Configuration
+@Import(MybatisMapperAutoConfiguration.AutoConfiguredMapperScannerRegistrar.class)
+@ConditionalOnClass({SqlSession.class, ClassPathMapperScanner.class})
+@ConditionalOnMissingBean(MapperFactoryBean.class)
+@ConditionalOnSingleCandidate(SqlSessionTemplate.class)
+@AutoConfigureAfter(MybatisAutoConfiguration.class)
+public class MybatisMapperAutoConfiguration {
+
+  private static Logger logger = LoggerFactory.getLogger(MybatisMapperAutoConfiguration.class);
+
+  /**
+   * This will just scan the same base package as Spring Boot does. If you want
+   * more power, you can explicitly use
+   * {@link org.mybatis.spring.annotation.MapperScan} but this will get typed
+   * mappers working correctly, out-of-the-box, similar to using Spring Data JPA
+   * repositories.
+   */
+  static class AutoConfiguredMapperScannerRegistrar
+          implements BeanFactoryAware, ImportBeanDefinitionRegistrar, ResourceLoaderAware {
+
+    private BeanFactory beanFactory;
+
+    private ResourceLoader resourceLoader;
+
+    @Override
+    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+
+      logger.debug("Searching for mappers annotated with @Mapper");
+
+      ClassPathMapperScanner scanner = new ClassPathMapperScanner(registry);
+
+      try {
+        if (this.resourceLoader != null) {
+          scanner.setResourceLoader(this.resourceLoader);
+        }
+
+        List<String> packages = AutoConfigurationPackages.get(this.beanFactory);
+        if (logger.isDebugEnabled()) {
+          for (String pkg : packages) {
+            logger.debug("Using auto-configuration base package '{}'", pkg);
+          }
+        }
+
+        scanner.setAnnotationClass(Mapper.class);
+        scanner.registerFilters();
+        scanner.doScan(StringUtils.toStringArray(packages));
+      } catch (IllegalStateException ex) {
+        logger.debug("Could not determine auto-configuration package, automatic mapper scanning disabled.");
+      }
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+      this.beanFactory = beanFactory;
+    }
+
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+      this.resourceLoader = resourceLoader;
+    }
+
+  }
+
+}

--- a/mybatis-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/mybatis-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 # Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration
+org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration,\
+org.mybatis.spring.boot.autoconfigure.MybatisMapperAutoConfiguration


### PR DESCRIPTION
Currently, injection error occur  when detect multiple datasource. I've modified to ignore auto configuration for sql session and mapper scan when detect multiple datasource.

This changes are depends on https://github.com/spring-projects/spring-boot/pull/6449 (Spring Boot 1.4).

Please review this.
