### PR TITLE
Add configurationProperties on MybatisProperties

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -117,6 +117,9 @@ public class MybatisAutoConfiguration {
       factory.setConfigLocation(this.resourceLoader.getResource(this.properties.getConfigLocation()));
     }
     factory.setConfiguration(properties.getConfiguration());
+    if (this.properties.getConfigurationProperties() != null) {
+      factory.setConfigurationProperties(this.properties.getConfigurationProperties());
+    }
     if (!ObjectUtils.isEmpty(this.interceptors)) {
       factory.setPlugins(this.interceptors);
     }

--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ExecutorType;
@@ -68,6 +69,11 @@ public class MybatisProperties {
    * Execution mode for {@link org.mybatis.spring.SqlSessionTemplate}.
    */
   private ExecutorType executorType;
+
+  /**
+   * Global properties for configuration.
+   */
+  private Properties configurationProperties;
 
   /**
    * A Configuration object for customize default settings. If {@link #configLocation}
@@ -140,6 +146,14 @@ public class MybatisProperties {
 
   public void setExecutorType(ExecutorType executorType) {
     this.executorType = executorType;
+  }
+
+  public Properties getConfigurationProperties() {
+    return configurationProperties;
+  }
+
+  public void setConfigurationProperties(Properties configurationProperties) {
+    this.configurationProperties = configurationProperties;
   }
 
   public Configuration getConfiguration() {

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.core.Is.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -405,6 +406,77 @@ public class MybatisAutoConfigurationTest {
 				.expectMessage("Property 'configuration' and 'configLocation' can not specified with together");
 
 		this.context.refresh();
+	}
+
+	@Test
+	public void testWithoutConfigurationVariablesAndProperties() {
+		EnvironmentTestUtils.addEnvironment(this.context);
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+
+		Properties variables = this.context.getBean(SqlSessionFactory.class).getConfiguration().getVariables();
+		assertNull(variables);
+	}
+
+	@Test
+	public void testWithConfigurationVariablesOnly() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.configuration.variables.key1:value1");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+
+		Properties variables = this.context.getBean(SqlSessionFactory.class).getConfiguration().getVariables();
+		assertEquals(1, variables.size());
+		assertEquals("value1", variables.get("key1"));
+	}
+
+	@Test
+	public void testWithConfigurationPropertiesOnly() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.configuration-properties.key2:value2");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+
+		Properties variables = this.context.getBean(SqlSessionFactory.class).getConfiguration().getVariables();
+		assertEquals(1, variables.size());
+		assertEquals("value2", variables.get("key2"));
+	}
+
+	@Test
+	public void testWithConfigurationVariablesAndPropertiesOtherKey() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.configuration.variables.key1:value1",
+				"mybatis.configuration-properties.key2:value2");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+
+		Properties variables = this.context.getBean(SqlSessionFactory.class).getConfiguration().getVariables();
+		assertEquals(2, variables.size());
+		assertEquals("value1", variables.get("key1"));
+		assertEquals("value2", variables.get("key2"));
+	}
+
+	@Test
+	public void testWithConfigurationVariablesAndPropertiesSameKey() {
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"mybatis.configuration.variables.key:value1",
+				"mybatis.configuration-properties.key:value2");
+		this.context.register(EmbeddedDataSourceConfiguration.class,
+				MybatisAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
+		this.context.refresh();
+
+		Properties variables = this.context.getBean(SqlSessionFactory.class).getConfiguration().getVariables();
+		assertEquals(1, variables.size());
+		assertEquals("value2", variables.get("key"));
 	}
 
 	@Configuration


### PR DESCRIPTION
I've added `configurationProperties` on `MybatisProperties` for customizing a global property.

`mybatis-config.xml`:

``` xml
<properties>
    <property name="key" value="value1" />
</properties>
```

Can override a defined property or define a new property  at `application.properties` as follows:

``` properties
mybatis.configuration-properties.key=value2
```

These properties can use as placeholder(`${...}` format) in `mybatis-config.xml` and SQL statement.  (In this case, `${key}` will replace to `value2`)

Please review.
