### PR TITLE
Fix to manage ognl and javassist using dependency management element on parent pom

### DIFF
--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/pom.xml
@@ -46,19 +46,11 @@
 		<dependency>
 			<groupId>ognl</groupId>
 			<artifactId>ognl</artifactId>
-			<version>3.1.2</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>javassist</groupId>
-					<artifactId>javassist</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
-			<version>3.20.0-GA</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/pom.xml
@@ -48,19 +48,11 @@
 		<dependency>
 			<groupId>ognl</groupId>
 			<artifactId>ognl</artifactId>
-			<version>3.1.2</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>javassist</groupId>
-					<artifactId>javassist</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
-			<version>3.20.0-GA</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mybatis-spring-boot-samples/pom.xml
+++ b/mybatis-spring-boot-samples/pom.xml
@@ -13,4 +13,24 @@
     <module>mybatis-spring-boot-sample-annotation</module>
     <module>mybatis-spring-boot-sample-xml</module>
   </modules>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>ognl</groupId>
+        <artifactId>ognl</artifactId>
+        <version>3.1.2</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <version>3.20.0-GA</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
I've improved to mange ognl and javassist using dependency management on sample applications.