### PR TITLE
Update to maven-bundle-plugin 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,4 +102,15 @@
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <plugins>
+      <!-- workaround for https://github.com/mybatis/spring-boot-starter/issues/127 -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
I've fixed gh-127 as workaround.
Please review this.

Configuration values in `MANIFEST.MF` are same excludes `Bnd-LastModified`, `Implementation-Build-Date` and `Tool`.

> Note that maven-bundle-plugin 3.x does not support JDK 6.
