### PR TITLE
Add mybatis-typehandlers-jsr310

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
   <properties>
     <mybatis.version>3.4.4</mybatis.version>
     <mybatis-spring.version>1.3.1</mybatis-spring.version>
+    <mybatis-typehandlers-jsr310.version>1.0.2</mybatis-typehandlers-jsr310.version>
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
   </properties>
 
@@ -83,6 +84,11 @@
         <groupId>org.mybatis</groupId>
         <artifactId>mybatis-spring</artifactId>
         <version>${mybatis-spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mybatis</groupId>
+        <artifactId>mybatis-typehandlers-jsr310</artifactId>
+        <version>${mybatis-typehandlers-jsr310.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mybatis.spring.boot</groupId>


### PR DESCRIPTION
It would be nice for spring-boot-starter to manage mybatis-typehandlers-jsr310.

I'd like to use managed versions like following:

``` xml
    <dependencies>
        <dependency>
            <groupId>org.mybatis.spring.boot</groupId>
            <artifactId>mybatis-spring-boot-starter</artifactId>
        </dependency>
        <dependency>
            <groupId>org.mybatis.spring.boot</groupId>
            <artifactId>mybatis-spring-boot-starter-test</artifactId>
            <scope>test</scope>
        </dependency>
        <dependency>
            <groupId>org.mybatis</groupId>
            <artifactId>mybatis-typehandlers-jsr310</artifactId>
        </dependency>
        <!-- ... -->
    </dependencies>

    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>org.springframework.boot</groupId>
                <artifactId>spring-boot-dependencies</artifactId>
                <version>1.5.2.RELEASE</version>
                <type>pom</type>
                <scope>import</scope>
            </dependency>
            <dependency>
                <groupId>org.mybatis.spring.boot</groupId>
                <artifactId>mybatis-spring-boot</artifactId>
                <version>1.3.x</version>
                <type>pom</type>
                <scope>import</scope>
            </dependency>
        </dependencies>
    </dependencyManagement>
```