### PR TITLE
Add junit-vintage-engine on maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,24 @@
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>org.junit.vintage</groupId>
+              <artifactId>junit-vintage-engine</artifactId>
+              <version>${junit-engine.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <repositories>
     <repository>
       <id>spring-snapshots</id>


### PR DESCRIPTION
See gh-236

I've added the `junit-vintage-engine on maven-surefire-plugin` for execution JUnit 4 tests.