### PR TITLE
Remove spring.provides files

### DIFF
--- a/mybatis-spring-boot-starter-test/src/main/resources/META-INF/spring.provides
+++ b/mybatis-spring-boot-starter-test/src/main/resources/META-INF/spring.provides
@@ -1,1 +1,0 @@
-provides: mybatis-spring-boot-test-autoconfigure

--- a/mybatis-spring-boot-starter/src/main/resources/META-INF/spring.provides
+++ b/mybatis-spring-boot-starter/src/main/resources/META-INF/spring.provides
@@ -1,1 +1,0 @@
-provides: mybatis-spring-boot-autoconfigure,mybatis,mybatis-spring


### PR DESCRIPTION
This PR removes the `spring.provides` files.

See https://github.com/spring-projects/spring-boot/issues/12435