### PR TITLE
Add spring-boot-autoconfigure-processor

### DIFF
--- a/mybatis-spring-boot-autoconfigure/pom.xml
+++ b/mybatis-spring-boot-autoconfigure/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2015-2017 the original author or authors.
+       Copyright 2015-2018 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -58,6 +58,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
 


### PR DESCRIPTION
This PR adds `spring-boot-autoconfigure-processor` to improve startup time with auto-configurations.

I confirmed a `spring-autoconfigure-metadata.properties` file has been created as follows:

```
$ find . -name spring-autoconfigure-metadata.properties
./mybatis-spring-boot-autoconfigure/target/classes/META-INF/spring-autoconfigure-metadata.properties
$ 
```

Closes gh-252