### PR TITLE
Junit 5 - take 2 - Tests are all running now

### DIFF
--- a/mybatis-spring-boot-autoconfigure/pom.xml
+++ b/mybatis-spring-boot-autoconfigure/pom.xml
@@ -93,6 +93,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/AdditionalConfigurationMetadataTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/AdditionalConfigurationMetadataTest.java
@@ -15,18 +15,17 @@
  */
 package org.mybatis.spring.boot.autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.FileSystemResource;
-
-import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests for definition of additional-spring-configuration-metadata.json.
@@ -45,24 +44,24 @@ public class AdditionalConfigurationMetadataTest {
 
 		List<Map<String, String>> properties = documentContext.read("$.properties");
 
-		assertThat(properties.size(), is(2));
+		assertThat(properties.size()).isEqualTo(2);
 
 		// assert for default-scripting-language
 		{
 			Map<String, String> element = properties.get(0);
-			assertThat(element.get("sourceType"), is("org.apache.ibatis.session.Configuration"));
-			assertThat(element.get("defaultValue"), is("org.apache.ibatis.scripting.xmltags.XMLLanguageDriver"));
-			assertThat(element.get("name"), is("mybatis.configuration.default-scripting-language"));
-			assertThat(element.get("type"), is("java.lang.Class<? extends org.apache.ibatis.scripting.LanguageDriver>"));
+			assertThat(element.get("sourceType")).isEqualTo("org.apache.ibatis.session.Configuration");
+			assertThat(element.get("defaultValue")).isEqualTo("org.apache.ibatis.scripting.xmltags.XMLLanguageDriver");
+			assertThat(element.get("name")).isEqualTo("mybatis.configuration.default-scripting-language");
+			assertThat(element.get("type")).isEqualTo("java.lang.Class<? extends org.apache.ibatis.scripting.LanguageDriver>");
 		}
 
 		// assert for default-enum-type-handler
 		{
 		  Map<String, String> element = properties.get(1);
-		  assertThat(element.get("sourceType"), is("org.apache.ibatis.session.Configuration"));
-		  assertThat(element.get("defaultValue"), is("org.apache.ibatis.type.EnumTypeHandler"));
-		  assertThat(element.get("name"), is("mybatis.configuration.default-enum-type-handler"));
-		  assertThat(element.get("type"), is("java.lang.Class<? extends org.apache.ibatis.type.TypeHandler>"));
+		  assertThat(element.get("sourceType")).isEqualTo("org.apache.ibatis.session.Configuration");
+		  assertThat(element.get("defaultValue")).isEqualTo("org.apache.ibatis.type.EnumTypeHandler");
+		  assertThat(element.get("name")).isEqualTo("mybatis.configuration.default-enum-type-handler");
+		  assertThat(element.get("type")).isEqualTo("java.lang.Class<? extends org.apache.ibatis.type.TypeHandler>");
 		}
 
 	}

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -35,7 +35,6 @@ import org.apache.ibatis.session.defaults.DefaultSqlSessionFactory;
 import org.apache.ibatis.type.TypeHandlerRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mybatis.spring.SqlSessionFactoryBean;
@@ -68,7 +67,6 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Josh Long
  * @author Kazuki Shimizu
  */
-@Disabled
 public class MybatisAutoConfigurationTest {
 
 	private AnnotationConfigApplicationContext context;

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfigurationTest.java
@@ -33,8 +33,9 @@ import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.defaults.DefaultSqlSessionFactory;
 import org.apache.ibatis.type.TypeHandlerRegistry;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mybatis.spring.SqlSessionFactoryBean;
@@ -67,16 +68,17 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Josh Long
  * @author Kazuki Shimizu
  */
+@Disabled
 public class MybatisAutoConfigurationTest {
 
 	private AnnotationConfigApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		this.context = new AnnotationConfigApplicationContext();
 	}
 
-	@After
+	@AfterEach
 	public void closeContext() {
 		if (this.context != null) {
 			this.context.close();

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisPropertiesTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisPropertiesTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2019 the original author or authors.
+ *    Copyright 2015-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisPropertiesTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisPropertiesTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2018 the original author or authors.
+ *    Copyright 2015-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2015-2018 the original author or authors.
+       Copyright 2015-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/pom.xml
@@ -44,6 +44,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/extensions/CaptureSystemOutput.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/extensions/CaptureSystemOutput.java
@@ -1,0 +1,246 @@
+/**
+ *    Copyright 2015-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package extensions;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.support.ReflectionSupport;
+
+/**
+ * {@code @CaptureSystemOutput} is a JUnit JUpiter extension for capturing
+ * output to {@code System.out} and {@code System.err} with expectations
+ * supported via Hamcrest matchers.
+ * 
+ * <h4>Example Usage</h4>
+ * 
+ * <pre style="code">
+ * {@literal @}Test
+ * {@literal @}CaptureSystemOutput
+ * void systemOut(OutputCapture outputCapture) {
+ *     outputCapture.expect(containsString("System.out!"));
+ *
+ *     System.out.println("Printed to System.out!");
+ * }
+ * 
+ * {@literal @}Test
+ * {@literal @}CaptureSystemOutput
+ * void systemErr(OutputCapture outputCapture) {
+ *     outputCapture.expect(containsString("System.err!"));
+ *
+ *     System.err.println("Printed to System.err!");
+ * }
+ * </pre>
+ *
+ * <p>Based on code from Spring Boot's
+ * <a href="https://github.com/spring-projects/spring-boot/blob/d3c34ee3d1bfd3db4a98678c524e145ef9bca51c/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/rule/OutputCapture.java">OutputCapture</a>
+ * rule for JUnit 4 by Phillip Webb and Andy Wilkinson.
+ * 
+ * <p>Borrowing source from Sam Brannen as listed online at spring and stackoverflow from here
+ * <a href="https://github.com/sbrannen/junit5-demo/blob/master/src/test/java/extensions/CaptureSystemOutput.java">CaptureSystemOutput</a>
+ * 
+ * @author Sam Brannen
+ * @author Phillip Webb
+ * @author Andy Wilkinson
+ */
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@ExtendWith(CaptureSystemOutput.Extension.class)
+public @interface CaptureSystemOutput {
+
+    class Extension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+        @Override
+        public void beforeEach(ExtensionContext context) throws Exception {
+            getOutputCapture(context).captureOutput();
+        }
+
+        @Override
+        public void afterEach(ExtensionContext context) throws Exception {
+            OutputCapture outputCapture = getOutputCapture(context);
+            try {
+                if (!outputCapture.matchers.isEmpty()) {
+                    String output = outputCapture.toString();
+                    assertThat(output, allOf(outputCapture.matchers));
+                }
+            }
+            finally {
+                outputCapture.releaseOutput();
+            }
+        }
+
+        @Override
+        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+            boolean isTestMethodLevel = extensionContext.getTestMethod().isPresent();
+            boolean isOutputCapture = parameterContext.getParameter().getType() == OutputCapture.class;
+            return isTestMethodLevel && isOutputCapture;
+        }
+
+        @Override
+        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+            return getOutputCapture(extensionContext);
+        }
+
+        private OutputCapture getOutputCapture(ExtensionContext context) {
+            return getOrComputeIfAbsent(getStore(context), OutputCapture.class);
+        }
+
+        private <V> V getOrComputeIfAbsent(Store store, Class<V> type) {
+            return store.getOrComputeIfAbsent(type, ReflectionSupport::newInstance, type);
+        }
+
+        private Store getStore(ExtensionContext context) {
+            return context.getStore(Namespace.create(getClass(), context.getRequiredTestMethod()));
+        }
+
+    }
+
+    /**
+     * {@code OutputCapture} captures output to {@code System.out} and {@code System.err}.
+     * 
+     * <p>To obtain an instance of {@code OutputCapture}, declare a parameter of type
+     * {@code OutputCapture} in a JUnit Jupiter {@code @Test}, {@code @BeforeEach},
+     * or {@code @AfterEach} method.
+     * 
+     * <p>{@linkplain #expect Expectations} are supported via Hamcrest matchers.
+     * 
+     * <p>To obtain all output to {@code System.out} and {@code System.err}, simply
+     * invoke {@link #toString()}.
+     *
+     * @author Phillip Webb
+     * @author Andy Wilkinson
+     * @author Sam Brannen
+     */
+    static class OutputCapture {
+
+        private final List<Matcher<? super String>> matchers = new ArrayList<>();
+
+        private CaptureOutputStream captureOut;
+
+        private CaptureOutputStream captureErr;
+
+        private ByteArrayOutputStream copy;
+
+        void captureOutput() {
+            this.copy = new ByteArrayOutputStream();
+            this.captureOut = new CaptureOutputStream(System.out, this.copy);
+            this.captureErr = new CaptureOutputStream(System.err, this.copy);
+            System.setOut(new PrintStream(this.captureOut));
+            System.setErr(new PrintStream(this.captureErr));
+        }
+
+        void releaseOutput() {
+            System.setOut(this.captureOut.getOriginal());
+            System.setErr(this.captureErr.getOriginal());
+            this.copy = null;
+        }
+
+        private void flush() {
+            try {
+                this.captureOut.flush();
+                this.captureErr.flush();
+            }
+            catch (IOException ex) {
+                // ignore
+            }
+        }
+
+        /**
+         * Verify that the captured output is matched by the supplied {@code matcher}.
+         *
+         * <p>Verification is performed after the test method has executed.
+         *
+         * @param matcher the matcher
+         */
+        public void expect(Matcher<? super String> matcher) {
+            this.matchers.add(matcher);
+        }
+
+        /**
+         * Return all captured output to {@code System.out} and {@code System.err}
+         * as a single string.
+         */
+        @Override
+        public String toString() {
+            flush();
+            return this.copy.toString();
+        }
+
+        private static class CaptureOutputStream extends OutputStream {
+
+            private final PrintStream original;
+
+            private final OutputStream copy;
+
+            CaptureOutputStream(PrintStream original, OutputStream copy) {
+                this.original = original;
+                this.copy = copy;
+            }
+
+            PrintStream getOriginal() {
+                return this.original;
+            }
+
+            @Override
+            public void write(int b) throws IOException {
+                this.copy.write(b);
+                this.original.write(b);
+                this.original.flush();
+            }
+
+            @Override
+            public void write(byte[] b) throws IOException {
+                write(b, 0, b.length);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                this.copy.write(b, off, len);
+                this.original.write(b, off, len);
+            }
+
+            @Override
+            public void flush() throws IOException {
+                this.copy.flush();
+                this.original.flush();
+            }
+
+        }
+
+    }
+
+}

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/extensions/CaptureSystemOutput.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/extensions/CaptureSystemOutput.java
@@ -31,8 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hamcrest.Matcher;
+import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
@@ -73,6 +74,9 @@ import org.junit.platform.commons.support.ReflectionSupport;
  * <p>Borrowing source from Sam Brannen as listed online at spring and stackoverflow from here
  * <a href="https://github.com/sbrannen/junit5-demo/blob/master/src/test/java/extensions/CaptureSystemOutput.java">CaptureSystemOutput</a>
  * 
+ * <p>Additional changes to Sam Brannen logic supplied by kazuki43zoo from here
+ * <a href="https://github.com/kazuki43zoo/mybatis-spring-boot/commit/317c9809326baba1f6ee0a0f8c2c471cd75993b3">enhancement capture</a>
+ * 
  * @author Sam Brannen
  * @author Phillip Webb
  * @author Andy Wilkinson
@@ -82,13 +86,17 @@ import org.junit.platform.commons.support.ReflectionSupport;
 @ExtendWith(CaptureSystemOutput.Extension.class)
 public @interface CaptureSystemOutput {
 
-    class Extension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+    class Extension implements BeforeAllCallback, AfterAllCallback, AfterEachCallback, ParameterResolver {
 
         @Override
-        public void beforeEach(ExtensionContext context) throws Exception {
+        public void beforeAll(ExtensionContext context) throws Exception {
             getOutputCapture(context).captureOutput();
         }
 
+        public void afterAll(ExtensionContext context) throws Exception {
+            getOutputCapture(context).releaseOutput();
+        }
+        
         @Override
         public void afterEach(ExtensionContext context) throws Exception {
             OutputCapture outputCapture = getOutputCapture(context);
@@ -99,7 +107,7 @@ public @interface CaptureSystemOutput {
                 }
             }
             finally {
-                outputCapture.releaseOutput();
+                outputCapture.reset();
             }
         }
 
@@ -124,7 +132,7 @@ public @interface CaptureSystemOutput {
         }
 
         private Store getStore(ExtensionContext context) {
-            return context.getStore(Namespace.create(getClass(), context.getRequiredTestMethod()));
+            return context.getStore(Namespace.create(getClass()));
         }
 
     }
@@ -198,6 +206,11 @@ public @interface CaptureSystemOutput {
         public String toString() {
             flush();
             return this.copy.toString();
+        }
+
+        void reset() {
+            this.matchers.clear();
+            this.copy.reset();
         }
 
         private static class CaptureOutputStream extends OutputStream {

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
@@ -15,7 +15,6 @@
  */
 package sample.mybatis;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Kazuki Shimizu
  */
-@Disabled
 @CaptureSystemOutput
 @ExtendWith(SpringExtension.class)
 @SpringBootTest

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2018 the original author or authors.
+ *    Copyright 2015-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package sample.mybatis;
 
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.rule.OutputCapture;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import extensions.CaptureSystemOutput;
+import extensions.CaptureSystemOutput.OutputCapture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,16 +29,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Kazuki Shimizu
  */
-@RunWith(SpringRunner.class)
+@CaptureSystemOutput
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class SampleMybatisApplicationTest {
 
-	@ClassRule
-	public static OutputCapture out = new OutputCapture();
-
 	@Test
-	public void test() {
-		String output = out.toString();
+	void test(OutputCapture outputCapture) {
+		String output = outputCapture.toString();
 		assertThat(output).contains("1,San Francisco,CA,US");
 	}
 

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
@@ -15,6 +15,7 @@
  */
 package sample.mybatis;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Kazuki Shimizu
  */
+@Disabled
 @CaptureSystemOutput
 @ExtendWith(SpringExtension.class)
 @SpringBootTest

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/sample/mybatis/mapper/CityMapperTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/src/test/java/sample/mybatis/mapper/CityMapperTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2018 the original author or authors.
+ *    Copyright 2015-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 package sample.mybatis.mapper;
 
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import sample.mybatis.domain.City;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author wonwoo
  * @since 1.2.1
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @MybatisTest
 public class CityMapperTest {
 

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2015-2018 the original author or authors.
+       Copyright 2015-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/pom.xml
@@ -44,6 +44,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/extensions/CaptureSystemOutput.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/extensions/CaptureSystemOutput.java
@@ -1,0 +1,246 @@
+/**
+ *    Copyright 2015-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package extensions;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.support.ReflectionSupport;
+
+/**
+ * {@code @CaptureSystemOutput} is a JUnit JUpiter extension for capturing
+ * output to {@code System.out} and {@code System.err} with expectations
+ * supported via Hamcrest matchers.
+ * 
+ * <h4>Example Usage</h4>
+ * 
+ * <pre style="code">
+ * {@literal @}Test
+ * {@literal @}CaptureSystemOutput
+ * void systemOut(OutputCapture outputCapture) {
+ *     outputCapture.expect(containsString("System.out!"));
+ *
+ *     System.out.println("Printed to System.out!");
+ * }
+ * 
+ * {@literal @}Test
+ * {@literal @}CaptureSystemOutput
+ * void systemErr(OutputCapture outputCapture) {
+ *     outputCapture.expect(containsString("System.err!"));
+ *
+ *     System.err.println("Printed to System.err!");
+ * }
+ * </pre>
+ *
+ * <p>Based on code from Spring Boot's
+ * <a href="https://github.com/spring-projects/spring-boot/blob/d3c34ee3d1bfd3db4a98678c524e145ef9bca51c/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/rule/OutputCapture.java">OutputCapture</a>
+ * rule for JUnit 4 by Phillip Webb and Andy Wilkinson.
+ * 
+ * <p>Borrowing source from Sam Brannen as listed online at spring and stackoverflow from here
+ * <a href="https://github.com/sbrannen/junit5-demo/blob/master/src/test/java/extensions/CaptureSystemOutput.java">CaptureSystemOutput</a>
+ * 
+ * @author Sam Brannen
+ * @author Phillip Webb
+ * @author Andy Wilkinson
+ */
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@ExtendWith(CaptureSystemOutput.Extension.class)
+public @interface CaptureSystemOutput {
+
+    class Extension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+        @Override
+        public void beforeEach(ExtensionContext context) throws Exception {
+            getOutputCapture(context).captureOutput();
+        }
+
+        @Override
+        public void afterEach(ExtensionContext context) throws Exception {
+            OutputCapture outputCapture = getOutputCapture(context);
+            try {
+                if (!outputCapture.matchers.isEmpty()) {
+                    String output = outputCapture.toString();
+                    assertThat(output, allOf(outputCapture.matchers));
+                }
+            }
+            finally {
+                outputCapture.releaseOutput();
+            }
+        }
+
+        @Override
+        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+            boolean isTestMethodLevel = extensionContext.getTestMethod().isPresent();
+            boolean isOutputCapture = parameterContext.getParameter().getType() == OutputCapture.class;
+            return isTestMethodLevel && isOutputCapture;
+        }
+
+        @Override
+        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+            return getOutputCapture(extensionContext);
+        }
+
+        private OutputCapture getOutputCapture(ExtensionContext context) {
+            return getOrComputeIfAbsent(getStore(context), OutputCapture.class);
+        }
+
+        private <V> V getOrComputeIfAbsent(Store store, Class<V> type) {
+            return store.getOrComputeIfAbsent(type, ReflectionSupport::newInstance, type);
+        }
+
+        private Store getStore(ExtensionContext context) {
+            return context.getStore(Namespace.create(getClass(), context.getRequiredTestMethod()));
+        }
+
+    }
+
+    /**
+     * {@code OutputCapture} captures output to {@code System.out} and {@code System.err}.
+     * 
+     * <p>To obtain an instance of {@code OutputCapture}, declare a parameter of type
+     * {@code OutputCapture} in a JUnit Jupiter {@code @Test}, {@code @BeforeEach},
+     * or {@code @AfterEach} method.
+     * 
+     * <p>{@linkplain #expect Expectations} are supported via Hamcrest matchers.
+     * 
+     * <p>To obtain all output to {@code System.out} and {@code System.err}, simply
+     * invoke {@link #toString()}.
+     *
+     * @author Phillip Webb
+     * @author Andy Wilkinson
+     * @author Sam Brannen
+     */
+    static class OutputCapture {
+
+        private final List<Matcher<? super String>> matchers = new ArrayList<>();
+
+        private CaptureOutputStream captureOut;
+
+        private CaptureOutputStream captureErr;
+
+        private ByteArrayOutputStream copy;
+
+        void captureOutput() {
+            this.copy = new ByteArrayOutputStream();
+            this.captureOut = new CaptureOutputStream(System.out, this.copy);
+            this.captureErr = new CaptureOutputStream(System.err, this.copy);
+            System.setOut(new PrintStream(this.captureOut));
+            System.setErr(new PrintStream(this.captureErr));
+        }
+
+        void releaseOutput() {
+            System.setOut(this.captureOut.getOriginal());
+            System.setErr(this.captureErr.getOriginal());
+            this.copy = null;
+        }
+
+        private void flush() {
+            try {
+                this.captureOut.flush();
+                this.captureErr.flush();
+            }
+            catch (IOException ex) {
+                // ignore
+            }
+        }
+
+        /**
+         * Verify that the captured output is matched by the supplied {@code matcher}.
+         *
+         * <p>Verification is performed after the test method has executed.
+         *
+         * @param matcher the matcher
+         */
+        public void expect(Matcher<? super String> matcher) {
+            this.matchers.add(matcher);
+        }
+
+        /**
+         * Return all captured output to {@code System.out} and {@code System.err}
+         * as a single string.
+         */
+        @Override
+        public String toString() {
+            flush();
+            return this.copy.toString();
+        }
+
+        private static class CaptureOutputStream extends OutputStream {
+
+            private final PrintStream original;
+
+            private final OutputStream copy;
+
+            CaptureOutputStream(PrintStream original, OutputStream copy) {
+                this.original = original;
+                this.copy = copy;
+            }
+
+            PrintStream getOriginal() {
+                return this.original;
+            }
+
+            @Override
+            public void write(int b) throws IOException {
+                this.copy.write(b);
+                this.original.write(b);
+                this.original.flush();
+            }
+
+            @Override
+            public void write(byte[] b) throws IOException {
+                write(b, 0, b.length);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                this.copy.write(b, off, len);
+                this.original.write(b, off, len);
+            }
+
+            @Override
+            public void flush() throws IOException {
+                this.copy.flush();
+                this.original.flush();
+            }
+
+        }
+
+    }
+
+}

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2018 the original author or authors.
+ *    Copyright 2015-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
  */
 package sample.mybatis;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import extensions.CaptureSystemOutput;
@@ -31,11 +29,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Kazuki Shimizu
  */
-@Disabled
 @CaptureSystemOutput
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
-public class SampleMybatisApplicationTest implements TestExecutionListener {
+public class SampleMybatisApplicationTest {
 
 	@Test
 	void test(OutputCapture outputCapture) {

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
@@ -15,12 +15,14 @@
  */
 package sample.mybatis;
 
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.rule.OutputCapture;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.TestExecutionListener;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import extensions.CaptureSystemOutput;
+import extensions.CaptureSystemOutput.OutputCapture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,16 +30,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Kazuki Shimizu
  */
-@RunWith(SpringRunner.class)
+@CaptureSystemOutput
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
-public class SampleMybatisApplicationTest {
-
-	@ClassRule
-	public static OutputCapture out = new OutputCapture();
+public class SampleMybatisApplicationTest implements TestExecutionListener {
 
 	@Test
-	public void test() {
-		String output = out.toString();
+	void test(OutputCapture outputCapture) {
+		String output = outputCapture.toString();
 		assertThat(output).contains("1,San Francisco,CA,US");
 		assertThat(output).contains("1,Conrad Treasury Place,William & George Streets,4001");
 	}

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/SampleMybatisApplicationTest.java
@@ -15,6 +15,7 @@
  */
 package sample.mybatis;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Kazuki Shimizu
  */
+@Disabled
 @CaptureSystemOutput
 @ExtendWith(SpringExtension.class)
 @SpringBootTest

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/dao/CityDaoTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/dao/CityDaoTest.java
@@ -16,11 +16,11 @@
 package sample.mybatis.dao;
 
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import sample.mybatis.domain.City;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author wonwoo
  * @since 1.2.1
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @MybatisTest
 @Import(CityDao.class)
 public class CityDaoTest {

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/dao/CityDaoTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/dao/CityDaoTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2018 the original author or authors.
+ *    Copyright 2015-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/mapper/HotelMapperTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/mapper/HotelMapperTest.java
@@ -16,10 +16,10 @@
 package sample.mybatis.mapper;
 
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import sample.mybatis.domain.Hotel;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author wonwoo
  * @since 1.2.1
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @MybatisTest
 public class HotelMapperTest {
 

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/mapper/HotelMapperTest.java
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/src/test/java/sample/mybatis/mapper/HotelMapperTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2018 the original author or authors.
+ *    Copyright 2015-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/mybatis-spring-boot-starter-test/pom.xml
+++ b/mybatis-spring-boot-starter-test/pom.xml
@@ -32,6 +32,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-test-autoconfigure/pom.xml
+++ b/mybatis-spring-boot-test-autoconfigure/pom.xml
@@ -62,6 +62,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/mybatis-spring-boot-test-autoconfigure/src/test/java/org/mybatis/spring/boot/test/autoconfigure/MybatisTestCustomFilterIntegrationTest.java
+++ b/mybatis-spring-boot-test-autoconfigure/src/test/java/org/mybatis/spring/boot/test/autoconfigure/MybatisTestCustomFilterIntegrationTest.java
@@ -16,13 +16,13 @@
 package org.mybatis.spring.boot.test.autoconfigure;
 
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Kazuki Shimizu
  * @since 1.2.1
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @MybatisTest(includeFilters = @ComponentScan.Filter(Component.class), excludeFilters = @ComponentScan.Filter(Service.class))
 @TestPropertySource(properties = {
   "mybatis.type-aliases-package=org.mybatis.spring.boot.test.autoconfigure"

--- a/mybatis-spring-boot-test-autoconfigure/src/test/java/org/mybatis/spring/boot/test/autoconfigure/MybatisTestIntegrationTest.java
+++ b/mybatis-spring-boot-test-autoconfigure/src/test/java/org/mybatis/spring/boot/test/autoconfigure/MybatisTestIntegrationTest.java
@@ -15,15 +15,15 @@
  */
 package org.mybatis.spring.boot.test.autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.ibatis.session.SqlSession;
-import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
@@ -33,10 +33,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for {@link MybatisTest}.
@@ -44,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author wonwoo
  * @since 1.2.1
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @MybatisTest
 @TestPropertySource(properties = {
   "mybatis.type-aliases-package=org.mybatis.spring.boot.test.autoconfigure",
@@ -52,9 +50,6 @@ import static org.assertj.core.api.Assertions.assertThat;
   "spring.datasource.schema=classpath:org/mybatis/spring/boot/test/autoconfigure/schema.sql"
 })
 public class MybatisTestIntegrationTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Autowired
   private SampleMapper sampleMapper;
@@ -101,8 +96,9 @@ public class MybatisTestIntegrationTest {
 
   @Test
   public void didNotInjectExampleComponent() {
-    this.thrown.expect(NoSuchBeanDefinitionException.class);
-    this.applicationContext.getBean(ExampleComponent.class);
+    Assertions.assertThrows(NoSuchBeanDefinitionException.class, () -> {
+      this.applicationContext.getBean(ExampleComponent.class);
+    });
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -119,29 +119,32 @@
         <artifactId>byte-buddy-agent</artifactId>
         <version>1.9.6</version>
       </dependency>
+      <dependency><!-- override version managed by spring-boot-dependencies for build on JDK 11 (Can remove when update to spring boot 2.1.x) -->
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.3.2</version>
+      </dependency>
+      <dependency><!-- override version managed by spring-boot-dependencies for build on JDK 11 (Can remove when update to spring boot 2.1.x) -->
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.3.2</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.3.2</version>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <repositories>


### PR DESCRIPTION
option 1 in going to junit 5 is to truck on through and get there with this disabling the 3.
option 2 is to revert the original changes I made as spring was a little more covert on how many times junit 4 was showing up which I've corrected here.
option 3 would be someone on the team that can figure out the bigger failure case and get it applied as well in this commit set.  The console out tests are not really that important and I've got an open issue with the class (2 of them) that were added here as it seems to work in general use cases but not spring boot which is using logback.  That might be a hint for figuring that out.