### PR TITLE
Support JDK 12 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 
 jdk:
+  - openjdk12
   - oraclejdk11
   - oraclejdk8
 


### PR DESCRIPTION
The JDK 12 has been released. I've added tests using JDK 12 on Travis CI.