### PR TITLE
Prevent warning of junit-vintage on spring-boot 2.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 script:
   - ./mvnw clean verify
-  - ./mvnw clean verify -Dspring-boot.version=2.1.11.RELEASE -Denforcer.fail=false
+  - ./mvnw clean verify -Dspring-boot.version=2.1.11.RELEASE -Dspring-boot.version.line=2.1.x
 
 after_success:
   - chmod -R 777 ./travis/after_success.sh

--- a/mybatis-spring-boot-autoconfigure/pom.xml
+++ b/mybatis-spring-boot-autoconfigure/pom.xml
@@ -108,12 +108,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
   </dependencies>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-annotation/pom.xml
@@ -44,12 +44,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-freemarker-legacy/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-freemarker-legacy/pom.xml
@@ -49,12 +49,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-freemarker/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-freemarker/pom.xml
@@ -48,12 +48,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-groovy/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-groovy/pom.xml
@@ -50,12 +50,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-kotlin/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-kotlin/pom.xml
@@ -54,12 +54,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-thymeleaf/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-thymeleaf/pom.xml
@@ -48,12 +48,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-velocity-legacy/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-velocity-legacy/pom.xml
@@ -49,12 +49,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-velocity/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-velocity/pom.xml
@@ -48,12 +48,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-war/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-war/pom.xml
@@ -53,12 +53,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-web/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-web/pom.xml
@@ -48,12 +48,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-xml/pom.xml
@@ -44,12 +44,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-starter-test/pom.xml
+++ b/mybatis-spring-boot-starter-test/pom.xml
@@ -32,12 +32,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>

--- a/mybatis-spring-boot-test-autoconfigure/pom.xml
+++ b/mybatis-spring-boot-test-autoconfigure/pom.xml
@@ -67,12 +67,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -132,16 +132,19 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <version>${spring-boot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <dependencies>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <scope>test</scope>
-      </dependency>
-  </dependencies>
 
   <repositories>
     <repository>
@@ -184,5 +187,24 @@
       </snapshots>
     </pluginRepository>
   </pluginRepositories>
+
+  <profiles>
+    <profile>
+      <id>spring-boor-2.1.x</id>
+      <activation>
+        <property>
+          <name>spring-boot.version.line</name>
+          <value>2.1.x</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
Prevent following warning.

```
Dec 10, 2019 4:05:00 PM org.junit.platform.launcher.core.DefaultLauncher handleThrowable
WARNING: TestEngine with ID 'junit-vintage' failed to discover tests
java.lang.NoClassDefFoundError: junit/runner/Version
	at org.junit.vintage.engine.JUnit4VersionCheck.checkSupported(JUnit4VersionCheck.java:32)
	at org.junit.vintage.engine.VintageTestEngine.discover(VintageTestEngine.java:61)
	at org.junit.platform.launcher.core.DefaultLauncher.discoverEngineRoot(DefaultLauncher.java:168)
	at org.junit.platform.launcher.core.DefaultLauncher.discoverRoot(DefaultLauncher.java:155)
	at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:120)
	at org.apache.maven.surefire.junitplatform.TestPlanScannerFilter.accept(TestPlanScannerFilter.java:56)
	at org.apache.maven.surefire.util.DefaultScanResult.applyFilter(DefaultScanResult.java:102)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.scanClasspath(JUnitPlatformProvider.java:143)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: java.lang.ClassNotFoundException: junit.runner.Version
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 13 more
```