### PR TITLE
align mybatis-velocity 2.0, 2.1.0 to 2.1.0

### DIFF
--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-velocity-legacy/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-velocity-legacy/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.mybatis.scripting</groupId>
       <artifactId>mybatis-velocity</artifactId>
-      <version>2.0</version>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>


### PR DESCRIPTION
align inconsistent mybatis-velocity versions to one to avoid inconsistent API behaviors.