### PR TITLE
Support interceptor sorting during auto config SqlSessionFactory

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -56,6 +56,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
@@ -140,6 +141,7 @@ public class MybatisAutoConfiguration implements InitializingBean {
       factory.setConfigurationProperties(this.properties.getConfigurationProperties());
     }
     if (!ObjectUtils.isEmpty(this.interceptors)) {
+      AnnotationAwareOrderComparator.sort(this.interceptors);
       factory.setPlugins(this.interceptors);
     }
     if (this.databaseIdProvider != null) {

--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java
@@ -141,6 +141,7 @@ public class MybatisAutoConfiguration implements InitializingBean {
       factory.setConfigurationProperties(this.properties.getConfigurationProperties());
     }
     if (!ObjectUtils.isEmpty(this.interceptors)) {
+      // sort interceptors by order
       AnnotationAwareOrderComparator.sort(this.interceptors);
       factory.setPlugins(this.interceptors);
     }


### PR DESCRIPTION
When autowire the interceptors, not respect the Spring sorting style (using `@Order` or implements the `Ordered` interface). Some scenarios will depend on the execution order of the Interceptor, such as expecting to obtain the rewritten SQL and parameters after the `PaginationInterceptor` is executed.