### PR TITLE
Change configuration for allowing override the tomcat major version on tests

### DIFF
--- a/mybatis-spring-boot-samples/mybatis-spring-boot-sample-war/pom.xml
+++ b/mybatis-spring-boot-samples/mybatis-spring-boot-sample-war/pom.xml
@@ -27,6 +27,7 @@
   <packaging>war</packaging>
   <name>mybatis-spring-boot-sample-war</name>
   <properties>
+    <tomcat.major.version>9</tomcat.major.version>
     <tomcat.version>9.0.56</tomcat.version>
 
     <module.name>org.mybatis.spring.boot.sample.war</module.name>
@@ -120,9 +121,9 @@
             </properties>
           </configuration>
           <container>
-            <containerId>tomcat9x</containerId>
+            <containerId>tomcat${tomcat.major.version}x</containerId>
             <zipUrlInstaller>
-              <url>https://archive.apache.org/dist/tomcat/tomcat-9/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+              <url>https://archive.apache.org/dist/tomcat/tomcat-${tomcat.major.version}/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
             </zipUrlInstaller>
           </container>
         </configuration>


### PR DESCRIPTION
See gh-607

The Spring Boot 3.0 requires the Tomcat 10.