### PR TITLE
Open `CoreConfiguration#applyTo`

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
@@ -657,7 +657,7 @@ public class MybatisProperties {
       this.defaultEnumTypeHandler = defaultEnumTypeHandler;
     }
 
-    void applyTo(Configuration target) {
+    public void applyTo(Configuration target) {
       PropertyMapper mapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
       mapper.from(getSafeRowBoundsEnabled()).to(target::setSafeRowBoundsEnabled);
       mapper.from(getSafeResultHandlerEnabled()).to(target::setSafeResultHandlerEnabled);


### PR DESCRIPTION
I want to open `CoreConfiguration#applyTo`.

## Why

### background

My application needs to connect to multiple MySQL instances, so I need to configure multiple datasource/mybatis.
(Because I am sharding MySQL and accessing replica for some queries).

Therefore, I was using mybatis-spring-starter with customize.
(To be more specific, I did not use `MybatisAutoConfiguration`, but wrote the equivalent configuration code myself.)

###  Attempting to upgrade mybatis-spring-boot-starter-3.x

`CoreConfiguration` is new in mybatis-spring-boot-starter-3.x.

I tried to modify our code to mimic [this method](https://github.com/mybatis/spring-boot-starter/blob/3bffc1fbe0c88a62d5f8df04c4726e030055c130/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisAutoConfiguration.java#L138), but the `CoreConfiguration#applyTo` is NOT public.

Currently, we copy&paste `CoreConfiguration#applyTo` to workaround.

## What Changes

Open `CoreConfiguration#applyTo`.

