### PR TITLE
Enable the thread context class loader in SpringBootVFS

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/SpringBootVFS.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/SpringBootVFS.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2015-2022 the original author or authors.
+ *    Copyright 2015-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.text.Normalizer;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,6 +30,7 @@ import org.apache.ibatis.io.VFS;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.util.ClassUtils;
 
 /**
  * @author Hans Westerbeek
@@ -38,14 +40,16 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 public class SpringBootVFS extends VFS {
 
   private static Charset urlDecodingCharset;
+  private static Supplier<ClassLoader> classLoaderSupplier;
   private final ResourcePatternResolver resourceResolver;
 
   static {
     setUrlDecodingCharset(Charset.defaultCharset());
+    setClassLoaderSupplier(ClassUtils::getDefaultClassLoader);
   }
 
   public SpringBootVFS() {
-    this.resourceResolver = new PathMatchingResourcePatternResolver(getClass().getClassLoader());
+    this.resourceResolver = new PathMatchingResourcePatternResolver(classLoaderSupplier.get());
   }
 
   @Override
@@ -75,6 +79,21 @@ public class SpringBootVFS extends VFS {
    */
   public static void setUrlDecodingCharset(Charset charset) {
     urlDecodingCharset = charset;
+  }
+
+  /**
+   * Set the supplier for providing {@link ClassLoader} to used.
+   * <p>
+   * Default is a returned instance from {@link ClassUtils#getDefaultClassLoader()}.
+   * </p>
+   *
+   * @param supplier
+   *          the supplier for providing {@link ClassLoader} to used
+   *
+   * @since 3.0.2
+   */
+  public static void setClassLoaderSupplier(Supplier<ClassLoader> supplier) {
+    classLoaderSupplier = supplier;
   }
 
   private static String preserveSubpackageName(final String baseUrlString, final Resource resource,


### PR DESCRIPTION
Fixes gh-542

* Use the returned instance from ClassUtils#getDefaultClassLoader()
* Can customize to use any class loader instance using Supplier