### PR TITLE
[GHA] Add 'site.yaml' to release the site

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -1,0 +1,34 @@
+name: Site
+
+on:
+  push:
+    branches:
+      - site
+
+jobs:
+  build:
+    if: github.repository_owner == 'mybatis' && ! contains(toJSON(github.event.head_commit.message), '[maven-release-plugin]')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: zulu
+      - uses: webfactory/ssh-agent@master
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Build site
+        run: ./mvnw site site:stage -DskipTests -B -V --no-transfer-progress -Dlicense.skip=true
+        env:
+          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy Site to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        with:
+          ssh-key: true
+          branch: gh-pages
+          folder: target/staging
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To use, simply merge code up to either tip of master or to tag you which to have the site release on.  Note, the later comment there up to the tag will actually be skipped in current form, assuming we want to do it that way, we will need to remove the check on the commit message.