### PR TITLE
Update to MyBatis 3.5.17

### DIFF
--- a/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
+++ b/mybatis-spring-boot-autoconfigure/src/main/java/org/mybatis/spring/boot/autoconfigure/MybatisProperties.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2015-2023 the original author or authors.
+ *    Copyright 2015-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.apache.ibatis.session.LocalCacheScope;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -446,6 +447,7 @@ public class MybatisProperties {
       this.aggressiveLazyLoading = aggressiveLazyLoading;
     }
 
+    @DeprecatedConfigurationProperty(since = "3.0.4", reason = "The option is not used at MyBatis core module. It will be removed in the future. See https://github.com/mybatis/mybatis-3/pull/3238")
     public Boolean getMultipleResultSetsEnabled() {
       return multipleResultSetsEnabled;
     }

--- a/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisPropertiesTest.java
+++ b/mybatis-spring-boot-autoconfigure/src/test/java/org/mybatis/spring/boot/autoconfigure/MybatisPropertiesTest.java
@@ -139,10 +139,12 @@ class MybatisPropertiesTest {
             .withPropertyValues("mybatis.configuration.aggressive-lazy-loading:true")
             .run(context -> assertThat(
                 context.getBean(SqlSessionFactory.class).getConfiguration().isAggressiveLazyLoading()).isTrue()),
+        // Since MyBatis 3.5.17, the return value of isMultipleResultSetsEnabled() is always true
+        // See https://github.com/mybatis/mybatis-3/pull/3238
         () -> this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
             .withPropertyValues("mybatis.configuration.multiple-result-sets-enabled:false")
             .run(context -> assertThat(
-                context.getBean(SqlSessionFactory.class).getConfiguration().isMultipleResultSetsEnabled()).isFalse()),
+                context.getBean(SqlSessionFactory.class).getConfiguration().isMultipleResultSetsEnabled()).isTrue()),
         () -> this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
             .withPropertyValues("mybatis.configuration.use-generated-keys:true")
             .run(context -> assertThat(context.getBean(SqlSessionFactory.class).getConfiguration().isUseGeneratedKeys())

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <java.version>17</java.version>
     <java.release.version>17</java.release.version>
 
-    <mybatis.version>3.5.16</mybatis.version>
+    <mybatis.version>3.5.17</mybatis.version>
     <mybatis-spring.version>3.0.4</mybatis-spring.version>
     <mybatis-freemarker.version>1.3.0</mybatis-freemarker.version>
     <mybatis-velocity.version>2.3.0</mybatis-velocity.version>


### PR DESCRIPTION
* multipleResultSetsEnabled deprecated

### Related Issues

* https://github.com/mybatis/mybatis-3/pull/3238