### PR TITLE
Add package-info.java for generating javadoc and source jar file

### DIFF
--- a/mybatis-spring-boot-starter-test/pom.xml
+++ b/mybatis-spring-boot-starter-test/pom.xml
@@ -27,6 +27,7 @@
   <name>mybatis-spring-boot-starter-test</name>
   <properties>
     <module.name>org.mybatis.spring.boot.starter.test</module.name>
+    <maven.javadoc.failOnError>false</maven.javadoc.failOnError> <!-- This setting added for generating javadoc jar file. -->
   </properties>
   <dependencies>
     <dependency>

--- a/mybatis-spring-boot-starter-test/src/main/java/org/mybatis/spring/boot/starter/test/package-info.java
+++ b/mybatis-spring-boot-starter-test/src/main/java/org/mybatis/spring/boot/starter/test/package-info.java
@@ -1,0 +1,20 @@
+/*
+ *    Copyright 2015-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/**
+ * MyBatis-Spring-Boot-Starter for testing.
+ */
+// This file added for generating javadoc jar and source jar file.
+package org.mybatis.spring.boot.starter.test;

--- a/mybatis-spring-boot-starter/pom.xml
+++ b/mybatis-spring-boot-starter/pom.xml
@@ -27,6 +27,7 @@
   <name>mybatis-spring-boot-starter</name>
   <properties>
     <module.name>org.mybatis.spring.boot.starter</module.name>
+    <maven.javadoc.failOnError>false</maven.javadoc.failOnError> <!-- This setting added for generating javadoc jar file. -->
   </properties>
   <dependencies>
     <dependency>

--- a/mybatis-spring-boot-starter/src/main/java/org/mybatis/spring/boot/starter/package-info.java
+++ b/mybatis-spring-boot-starter/src/main/java/org/mybatis/spring/boot/starter/package-info.java
@@ -1,0 +1,20 @@
+/*
+ *    Copyright 2015-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/**
+ * MyBatis-Spring-Boot-Starter.
+ */
+// This file added for generating javadoc jar and source jar file.
+package org.mybatis.spring.boot.starter;


### PR DESCRIPTION
I add `package-info.java` for generating javadoc and source jar file at starter projects. The `maven.javadoc.failOnError` option need for generate the javadoc jar file with only `package-info.java` file.

**NOTE:** We need to generate javadoc and source jar files for deploying to Maven Central repository.