### PR TITLE
Remove exclusion the commons-logging form spring-test

### DIFF
--- a/mybatis-spring-boot-test-autoconfigure/pom.xml
+++ b/mybatis-spring-boot-test-autoconfigure/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2015-2024 the original author or authors.
+       Copyright 2015-2025 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -44,12 +44,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
In Spring Boot 4.x line, it need the commons-logging 1.3 line. But In mybatis-spring-boot-test-autoconfigure, commons-logging exclude from spring-test, Therefore occur the build error. We remove the commons-logging from exclution setting for fixing this behavior. I've confirmed that it become same dependencies using `mvn dependency:tree` as difference from exclusion and non exclusion on Spring Boot 3.x line.
In this changes, master branch works on Spring Boot 3.x and 4.x.
